### PR TITLE
ci(pre-commit): automatically install commit-msg hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 # .pre-commit-config.yaml
+default_stages: [pre-commit, pre-merge-commit]
+default_install_hook_types: [pre-commit, pre-merge-commit, commit-msg]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
Adds the commit-msg stage to default installed stages in pre-commit; sets the pre-commit stage as default stage.